### PR TITLE
updated formatTime(data) method to handle am/pm

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -997,8 +997,8 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         let hours = date.getHours();
         let minutes = date.getMinutes();
         let seconds = date.getSeconds();
-        
-        if(this.hourFormat == '12' && hours > 11 && hours != 12) {
+        this.pm = hours > 11;
+        if(this.hourFormat == '12' && this.pm && hours != 12) {
             hours-=12;
         }
         
@@ -1012,7 +1012,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         }
         
         if(this.hourFormat == '12') {
-            output += hours > 11 ? ' PM' : ' AM';
+            output += this.pm ? ' PM' : ' AM';
         }
         
         return output;


### PR DESCRIPTION
fix for: p-calendar timeonly is not showing the correct time in input box